### PR TITLE
🐛 FIX: compilation on Docker

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -40,7 +40,7 @@ abinit_config_options:
   # by default CFLAGS = CXXFLAGS = "-g -O2 -mtune=native -march=native"
   # but for Docker we do not want to use the spec of the host machine
   # (see https://stackoverflow.com/a/54163496/5033292)
-  with_optim_flavor: "{{ 'safe' if (cloud_platform and cloud_platform == 'docker') else 'standard' }}"
+  with_optim_flavor: "{{ 'safe' if (cloud_platform is defined and cloud_platform == 'docker') else 'standard' }}"
   # alternatively you could set:
   # CFLAGS: "-g -O2"
   # CXXFLAGS: "-g -O2"

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -22,6 +22,7 @@ abinit_executables:
   plugin: abinit
 
 # See https://docs.abinit.org/INSTALL_Ubuntu/
+# see also options defined in abinit/config/specs/options.conf
 abinit_config_options:
   # mandatory libraries
   # ("yes" means auto-detect or provide a direct path.)
@@ -35,6 +36,14 @@ abinit_config_options:
   # linear algebra settings
   with_linalg_flavor: "netlib"
   LINALG_LIBS: "-L/usr/lib/x86_64-linux-gnu -llapack -lblas"
+
+  # by default CFLAGS = CXXFLAGS = "-g -O2 -mtune=native -march=native"
+  # but for Docker we do not want to use the spec of the host machine
+  # (see https://stackoverflow.com/a/54163496/5033292)
+  with_optim_flavor: "{{ 'safe' if (cloud_platform and cloud_platform == 'docker') else 'standard' }}"
+  # alternatively you could set:
+  # CFLAGS: "-g -O2"
+  # CXXFLAGS: "-g -O2"
 
 abinit_tests:
 # - atompaw

--- a/molecule/default/molecule.yml
+++ b/molecule/default/molecule.yml
@@ -31,5 +31,6 @@ provisioner:
       all:
         vars:
           ansible_python_interpreter: /usr/bin/python3
+          cloud_platform: docker
           run_tests: true
           test_libxc: "${MOLECULE_LIBXC:-no}"  # run marvel-nccr.libxc first


### PR DESCRIPTION
On Docker the image should not be compiled to use the host's spec,
since it could be used on another platform