### PR TITLE
👌 IMPROVE: Install parallel NetCDF

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -5,18 +5,24 @@
     update_cache: yes
     cache_valid_time: 36000
     name:
+    # compiler
     - gfortran
+    # MPI
     - openmpi-common
     - openmpi-bin
     - libopenmpi-dev
-    - libblacs-mpi-dev  # this is not available on ubuntu 20.04
+    # Linear Algebra libraries
+    - libblacs-mpi-dev  # this is not yet available on ubuntu 20.04
     - libblas-dev
-    - libhdf5-openmpi-dev
     - liblapack-dev
+    - libscalapack-mpi-dev
+    # libraries to write/read binary files in netcdf4 format
+    - libhdf5-openmpi-dev
     - libnetcdf-dev
     - libnetcdff-dev
-    - libscalapack-mpi-dev
+    - libpnetcdf-dev
     - netcdf-bin
+    # additional build tools
     - unzip
     # - build-essential  # this would be required by ubuntu 20.04
 

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -18,9 +18,10 @@
     - libscalapack-mpi-dev
     # libraries to write/read binary files in netcdf4 format
     - libhdf5-openmpi-dev
+    - libpnetcdf-dev
+    - pnetcdf-bin
     - libnetcdf-dev
     - libnetcdff-dev
-    - libpnetcdf-dev
     - netcdf-bin
     # additional build tools
     - unzip


### PR DESCRIPTION
This was intended to fix the warning in the output file (installing [`libpnetcdf-dev`](https://packages.debian.org/stretch/libpnetcdf-dev)):

```
--- !WARNING
src_file: m_nctk.F90
src_line: 564
message: |
    Netcdf lib does not support MPI-IO and: NetCDF: Parallel operation on file opened for non-parallel access
...

  Asked to delete not existent file: __TMP_FILE__

--- !WARNING
src_file: m_nctk.F90
src_line: 584
message: |
    The netcdf library does not support parallel IO, see message above
    Abinit won't be able to produce files in parallel e.g. when paral_kgb==1 is used.
    Action: install a netcdf4+HDF5 library with MPI-IO support.
...
```

From https://docs.abinit.org/INSTALL_Ubuntu/:

> HDF5, NetCDF and NetCDF-Fortran, libraries to write/read binary files in netcdf4 format. These libraries are available via the libhdf5-dev, libnetcdf-dev and libnetcdff-dev packages from apt. For parallel IO, the libpnetcdf-dev is required.

However, with this addition it is currently still present.
So perhaps it has to be specifically linked to in some way?